### PR TITLE
Fix the link for "Extrait du registre des poursuites"

### DIFF
--- a/_life/accommodation.md
+++ b/_life/accommodation.md
@@ -16,7 +16,7 @@ you will need requires certain paperwork that you will only be able to do once y
 
 * Valid Swiss residency permit (OR at least a Certificat d'inscription)
 * Last three payslips (OR if not available at minimum current employment certificate)
-* Extrait du registre des poursuites (can be requested [here](https://www.vd.ch/prestation-detail/prestation/demander-un-extrait-du-registre-des-poursuites-pour-soi-meme/?tx_vdprestations_pi4%5Bcontroller%5D=Prestation&tx_vdprestations_pi4%5Baction%5D=show&cHash=fa375835ef87030e235f9b5d7cd01b2f) once you have registered)
+* Extrait du registre des poursuites (can be requested [here](https://www.vd.ch/prestation/demander-un-extrait-du-registre-des-poursuites-pour-soi-meme) once you have registered)
 * Proof of home insurance (optional but strongly recommended for your dossier to be considered)
 
 An alternative is always to provide these documents for a Swiss guarantor whose name would be on the lease rather than for you personally.


### PR DESCRIPTION
The link for "Extrait du registre des poursuites" on the accommodation page is no longer valid and the page is moved.
This commit fixes the broken link.