### PR TITLE
Fix broken link to VaudTax in tax filing guide

### DIFF
--- a/_life/money.md
+++ b/_life/money.md
@@ -113,7 +113,7 @@ The general principles of Swiss taxation are:
 ⚠️ _The remainder of this page is a helpful guide to common taxable items and deductions in the canton of Vaud, not tax advice about your personal situation._
 _You should still read every field in the tax form at least once to ensure you do not forget anything._ ⚠️
 
-Filing taxes in the canton of Vaud is done via [VaudTax](https://www.vd.ch/etat-droit-finances/impots/impots-pour-les-individus/remplir-ma-declaration-dimpot/vaudtax),
+Filing taxes in the canton of Vaud is done via [VaudTax](https://www.vd.ch/vaudtax),
 the government-provided online tool that figures out your federal, cantonal, and communal taxes for you based on data you input.
 
 If you are not a permanent resident:


### PR DESCRIPTION
The link `vd.ch/vaudtax` is what is written in the taxing mail I recived from Canton so I guess it should be the right permanent link to access taxing service